### PR TITLE
Add json builder to the compatible builders' list.

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -32,7 +32,7 @@ def get_compatible_builders(app):
     builders = ['html', 'singlehtml', 'dirhtml',
                 'readthedocs', 'readthedocsdirhtml',
                 'readthedocssinglehtml', 'readthedocssinglehtmllocalmedia',
-                'spelling']
+                'spelling', 'json']
     builders.extend(app.config['sphinx_tabs_valid_builders'])
     return builders
 


### PR DESCRIPTION
This pull request adds `json` serializing builder to the list of compatible builders, to ensure static assets like CSS and JS files are copied for a client application to pick them up. 