### PR TITLE
Allow linkcheck

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -32,7 +32,7 @@ def get_compatible_builders(app):
     builders = ['html', 'singlehtml', 'dirhtml',
                 'readthedocs', 'readthedocsdirhtml',
                 'readthedocssinglehtml', 'readthedocssinglehtmllocalmedia',
-                'spelling']
+                'spelling', 'linkcheck']
     builders.extend(app.config['sphinx_tabs_valid_builders'])
     return builders
 


### PR DESCRIPTION
I love the tabs, but sphinx-tabs prevents linkcheck from succeeding:
```
WARNING: Not copying tabs assets! Not compatible with linkcheck builder
```
This simply adds linkcheck as a compatible builder so that they don't conflict.