### PR TITLE
🐛 FIX: Replace `add_javascript` by `add_js` for sphinx>=3

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%

--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -4,6 +4,7 @@ import base64
 import json
 import os
 import posixpath
+import sphinx
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from pkg_resources import resource_filename
@@ -346,7 +347,11 @@ def setup(app):
             if "add_script_file" in dir(app):
                 app.add_script_file(path)
             else:
-                app.add_javascript(path)
+                # check sphinx version for backward compatibility
+                if sphinx.version_info >= (3, 0):
+                    app.add_js_file(path)
+                else:
+                    app.add_javascript(path)
     app.connect("html-page-context", update_context)
     app.connect("build-finished", copy_assets)
 


### PR DESCRIPTION
Replaces #59 
Closes #58 

Includes backwards compatibility