### PR TITLE
🐛 FIX: nested parsing of tab labels

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -146,7 +146,11 @@ class TabDirective(SphinxDirective):
         else:
             tab_id = self.tab_id
 
-        tab_name = SphinxTabsTab(text=self.content[0])
+        tab_name = SphinxTabsTab()
+        self.state.nested_parse(self.content[0:1], 0, tab_name)
+        # Remove the paragraph node that is created by nested_parse
+        tab_name.children[0].replace_self(tab_name.children[0].children)
+
         tab_name["classes"].append("sphinx-tabs-tab")
         tab_name["classes"].extend(sorted(self.tab_classes))
 

--- a/tests/test_build/test_nested_markup.html
+++ b/tests/test_build/test_nested_markup.html
@@ -11,10 +11,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-0-0-0" aria-selected="true" class="sphinx-tabs-tab" id="tab-0-0-0" name="0-0" role="tab" tabindex="0">
-       **bold** tab
+       <strong>
+        bold
+       </strong>
+       tab
       </button>
       <button aria-controls="panel-0-0-1" aria-selected="false" class="sphinx-tabs-tab" id="tab-0-0-1" name="0-1" role="tab" tabindex="-1">
-       *italic* tab
+       <em>
+        italic
+       </em>
+       tab
       </button>
      </div>
      <div aria-labelledby="tab-0-0-0" class="sphinx-tabs-panel" id="panel-0-0-0" name="0-0" role="tabpanel" tabindex="0">
@@ -37,10 +43,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-1-Kipib2xkKiogZ3JvdXAgdGFi" aria-selected="true" class="sphinx-tabs-tab group-tab" id="tab-1-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tab" tabindex="0">
-       **bold** group tab
+       <strong>
+        bold
+       </strong>
+       group tab
       </button>
       <button aria-controls="panel-1-Kml0YWxpYyogZ3JvdXAgdGFi" aria-selected="false" class="sphinx-tabs-tab group-tab" id="tab-1-Kml0YWxpYyogZ3JvdXAgdGFi" name="Kml0YWxpYyogZ3JvdXAgdGFi" role="tab" tabindex="-1">
-       *italic* group tab
+       <em>
+        italic
+       </em>
+       group tab
       </button>
      </div>
      <div aria-labelledby="tab-1-Kipib2xkKiogZ3JvdXAgdGFi" class="sphinx-tabs-panel group-tab" id="panel-1-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tabpanel" tabindex="0">
@@ -63,10 +75,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-2-Kipib2xkKiogZ3JvdXAgdGFi" aria-selected="true" class="sphinx-tabs-tab group-tab" id="tab-2-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tab" tabindex="0">
-       **bold** group tab
+       <strong>
+        bold
+       </strong>
+       group tab
       </button>
       <button aria-controls="panel-2-Kml0YWxpYyogZ3JvdXAgdGFi" aria-selected="false" class="sphinx-tabs-tab group-tab" id="tab-2-Kml0YWxpYyogZ3JvdXAgdGFi" name="Kml0YWxpYyogZ3JvdXAgdGFi" role="tab" tabindex="-1">
-       *italic* group tab
+       <em>
+        italic
+       </em>
+       group tab
       </button>
      </div>
      <div aria-labelledby="tab-2-Kipib2xkKiogZ3JvdXAgdGFi" class="sphinx-tabs-panel group-tab" id="panel-2-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tabpanel" tabindex="0">
@@ -89,10 +107,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-3-3-0" aria-selected="true" class="sphinx-tabs-tab" id="tab-3-3-0" name="3-0" role="tab" tabindex="0">
-       :math:`x = y` tab
+       <span class="math notranslate nohighlight">
+        \(x = y\)
+       </span>
+       tab
       </button>
       <button aria-controls="panel-3-3-1" aria-selected="false" class="sphinx-tabs-tab" id="tab-3-3-1" name="3-1" role="tab" tabindex="-1">
-       :math:`x \neq y` tab
+       <span class="math notranslate nohighlight">
+        \(x \neq y\)
+       </span>
+       tab
       </button>
      </div>
      <div aria-labelledby="tab-3-3-0" class="sphinx-tabs-panel" id="panel-3-3-0" name="3-0" role="tabpanel" tabindex="0">
@@ -117,10 +141,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" aria-selected="true" class="sphinx-tabs-tab group-tab" id="tab-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tab" tabindex="0">
-       :math:`x = y` group tab
+       <span class="math notranslate nohighlight">
+        \(x = y\)
+       </span>
+       group tab
       </button>
       <button aria-controls="panel-4-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" aria-selected="false" class="sphinx-tabs-tab group-tab" id="tab-4-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" role="tab" tabindex="-1">
-       :math:`x \neq y` group tab
+       <span class="math notranslate nohighlight">
+        \(x \neq y\)
+       </span>
+       group tab
       </button>
      </div>
      <div aria-labelledby="tab-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" class="sphinx-tabs-panel group-tab" id="panel-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tabpanel" tabindex="0">
@@ -145,10 +175,16 @@
     <div class="sphinx-tabs docutils container">
      <div aria-label="Tabbed content" role="tablist">
       <button aria-controls="panel-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" aria-selected="true" class="sphinx-tabs-tab group-tab" id="tab-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tab" tabindex="0">
-       :math:`x = y` group tab
+       <span class="math notranslate nohighlight">
+        \(x = y\)
+       </span>
+       group tab
       </button>
       <button aria-controls="panel-5-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" aria-selected="false" class="sphinx-tabs-tab group-tab" id="tab-5-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" role="tab" tabindex="-1">
-       :math:`x \neq y` group tab
+       <span class="math notranslate nohighlight">
+        \(x \neq y\)
+       </span>
+       group tab
       </button>
      </div>
      <div aria-labelledby="tab-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" class="sphinx-tabs-panel group-tab" id="panel-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tabpanel" tabindex="0">

--- a/tests/test_build/test_nested_markup.xml
+++ b/tests/test_build/test_nested_markup.xml
@@ -5,9 +5,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-0-0-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-0-0-0" name="0-0" role="tab" tabindex="0">
-                    **bold** tab
+                    <strong>
+                        bold
+                     tab
                 <button aria-controls="panel-0-0-1" aria-selected="false" classes="sphinx-tabs-tab" ids="tab-0-0-1" name="0-1" role="tab" tabindex="-1">
-                    *italic* tab
+                    <emphasis>
+                        italic
+                     tab
             <div aria-labelledby="tab-0-0-0" classes="sphinx-tabs-panel" ids="panel-0-0-0" name="0-0" role="tabpanel" tabindex="0">
                 <paragraph>
                     <strong>
@@ -21,9 +25,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-1-Kipib2xkKiogZ3JvdXAgdGFi" aria-selected="true" classes="sphinx-tabs-tab group-tab" ids="tab-1-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tab" tabindex="0">
-                    **bold** group tab
+                    <strong>
+                        bold
+                     group tab
                 <button aria-controls="panel-1-Kml0YWxpYyogZ3JvdXAgdGFi" aria-selected="false" classes="sphinx-tabs-tab group-tab" ids="tab-1-Kml0YWxpYyogZ3JvdXAgdGFi" name="Kml0YWxpYyogZ3JvdXAgdGFi" role="tab" tabindex="-1">
-                    *italic* group tab
+                    <emphasis>
+                        italic
+                     group tab
             <div aria-labelledby="tab-1-Kipib2xkKiogZ3JvdXAgdGFi" classes="sphinx-tabs-panel group-tab" ids="panel-1-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tabpanel" tabindex="0">
                 <paragraph>
                     <strong>
@@ -37,9 +45,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-2-Kipib2xkKiogZ3JvdXAgdGFi" aria-selected="true" classes="sphinx-tabs-tab group-tab" ids="tab-2-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tab" tabindex="0">
-                    **bold** group tab
+                    <strong>
+                        bold
+                     group tab
                 <button aria-controls="panel-2-Kml0YWxpYyogZ3JvdXAgdGFi" aria-selected="false" classes="sphinx-tabs-tab group-tab" ids="tab-2-Kml0YWxpYyogZ3JvdXAgdGFi" name="Kml0YWxpYyogZ3JvdXAgdGFi" role="tab" tabindex="-1">
-                    *italic* group tab
+                    <emphasis>
+                        italic
+                     group tab
             <div aria-labelledby="tab-2-Kipib2xkKiogZ3JvdXAgdGFi" classes="sphinx-tabs-panel group-tab" ids="panel-2-Kipib2xkKiogZ3JvdXAgdGFi" name="Kipib2xkKiogZ3JvdXAgdGFi" role="tabpanel" tabindex="0">
                 <paragraph>
                     <strong>
@@ -53,9 +65,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-3-3-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-3-3-0" name="3-0" role="tab" tabindex="0">
-                    :math:`x = y` tab
+                    <math>
+                        x = y
+                     tab
                 <button aria-controls="panel-3-3-1" aria-selected="false" classes="sphinx-tabs-tab" ids="tab-3-3-1" name="3-1" role="tab" tabindex="-1">
-                    :math:`x \neq y` tab
+                    <math>
+                        x \neq y
+                     tab
             <div aria-labelledby="tab-3-3-0" classes="sphinx-tabs-panel" ids="panel-3-3-0" name="3-0" role="tabpanel" tabindex="0">
                 <paragraph>
                     Variables are equal 
@@ -71,9 +87,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" aria-selected="true" classes="sphinx-tabs-tab group-tab" ids="tab-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tab" tabindex="0">
-                    :math:`x = y` group tab
+                    <math>
+                        x = y
+                     group tab
                 <button aria-controls="panel-4-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" aria-selected="false" classes="sphinx-tabs-tab group-tab" ids="tab-4-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" role="tab" tabindex="-1">
-                    :math:`x \neq y` group tab
+                    <math>
+                        x \neq y
+                     group tab
             <div aria-labelledby="tab-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" classes="sphinx-tabs-panel group-tab" ids="panel-4-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tabpanel" tabindex="0">
                 <paragraph>
                     Variables are equal 
@@ -89,9 +109,13 @@
         <container classes="sphinx-tabs" type="tab-element">
             <div aria-label="Tabbed content" role="tablist">
                 <button aria-controls="panel-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" aria-selected="true" classes="sphinx-tabs-tab group-tab" ids="tab-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tab" tabindex="0">
-                    :math:`x = y` group tab
+                    <math>
+                        x = y
+                     group tab
                 <button aria-controls="panel-5-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" aria-selected="false" classes="sphinx-tabs-tab group-tab" ids="tab-5-Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggXG5lcSB5YCBncm91cCB0YWI=" role="tab" tabindex="-1">
-                    :math:`x \neq y` group tab
+                    <math>
+                        x \neq y
+                     group tab
             <div aria-labelledby="tab-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" classes="sphinx-tabs-panel group-tab" ids="panel-5-Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" name="Om1hdGg6YHggPSB5YCBncm91cCB0YWI=" role="tabpanel" tabindex="0">
                 <paragraph>
                     Variables are equal 


### PR DESCRIPTION
v2.0.0 stopped parsing reST content within tab labels. Re-implemented here. This feature was already included in tests, so test regression is also fixed here.

The example:
```
.. tabs::

   .. tab:: :math:`\frac{ \sum_{t=0}^{N}f(t,k) }{N}`


      Some content
```
Produces:

![image](https://user-images.githubusercontent.com/31405412/107124133-d9e6d200-6899-11eb-8fd0-6bfd4accb7cd.png)


Fixes #100 and fixes #101  