### PR TITLE
Fix parsing for unsupported builders, including rinohtype (for pdf)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
             "pygments",
             "sphinx_testing",
             "bs4",
+            "rinohtype",
         ],
         "code_style": ["pre-commit==2.6"],
     },

--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -183,8 +183,15 @@ class TabDirective(SphinxDirective):
         self.state.nested_parse(self.content[2:], self.content_offset, panel)
 
         if self.env.app.builder.name not in get_compatible_builders(self.env.app):
+            # Use base docutils classes
             outer_node = nodes.container()
             tab = nodes.container()
+            tab_name = nodes.container()
+            panel = nodes.container()
+
+            self.state.nested_parse(self.content[0:1], 0, tab_name)
+            self.state.nested_parse(self.content[2:], self.content_offset, panel)
+
             tab += tab_name
             outer_node += tab
             outer_node += panel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def auto_build_and_check(
     request,
 ):
     """
-    Build and check build success and  output regressions.
+    Build and check build success and output regressions.
     Currently all tests start with this.
     Disable using a `noautobuild` mark.
     """
@@ -80,12 +80,17 @@ def regress_sphinx_app_output(file_regression, get_sphinx_app_output):
     ):
         content = get_sphinx_app_output(app, buildername, filename, encoding)
 
-        soup = BeautifulSoup(content, "html.parser")
-        doc_div = soup.findAll("div", {"class": "documentwrapper"})[0]
-        text = doc_div.prettify()
-        for find, rep in (replace or {}).items():
-            text = text.replace(find, rep)
-        file_regression.check(text, extension=".html", encoding="utf8")
+        if buildername == "html":
+            soup = BeautifulSoup(content, "html.parser")
+            doc_div = soup.findAll("div", {"class": "documentwrapper"})[0]
+            doc = doc_div.prettify()
+            for find, rep in (replace or {}).items():
+                doc = text.replace(find, rep)
+        else:
+            doc = content
+        file_regression.check(
+            doc, extension="." + filename.split(".")[-1], encoding="utf8"
+        )
 
     return read
 

--- a/tests/roots/test-rinohtype-pdf/conf.py
+++ b/tests/roots/test-rinohtype-pdf/conf.py
@@ -1,0 +1,9 @@
+project = "sphinx-tabs test"
+master_doc = "index"
+source_suffix = ".rst"
+extensions = ["sphinx_tabs.tabs", "rinoh.frontend.sphinx"]
+pygments_style = "sphinx"
+
+rinoh_documents = [
+    dict(doc=master_doc, target="test"),
+]

--- a/tests/roots/test-rinohtype-pdf/index.rst
+++ b/tests/roots/test-rinohtype-pdf/index.rst
@@ -1,0 +1,9 @@
+
+TESTING PDF
+===========
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   tabs

--- a/tests/roots/test-rinohtype-pdf/tabs.rst
+++ b/tests/roots/test-rinohtype-pdf/tabs.rst
@@ -1,0 +1,24 @@
+============
+Testing Tabs
+============
+
+The following should be rendered as a list of plain text items.
+
+BEGIN_TEST
+
+.. tabs::
+
+   .. tab:: Apples
+
+      Apples are green, or sometimes red.
+
+   .. tab:: Pears
+
+      Pears are green.
+
+   .. tab:: Oranges
+
+      Oranges are orange.
+
+
+END_of_TEST

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,4 +1,5 @@
 import pytest
+from sphinx.application import Sphinx
 
 
 @pytest.mark.sphinx(testroot="basic")
@@ -33,3 +34,14 @@ def test_nested_markup(app, check_asset_links):
 @pytest.mark.sphinx(testroot="customlexer")
 def test_custom_lexer(app, check_asset_links):
     check_asset_links(app)
+
+
+@pytest.mark.noautobuild
+@pytest.mark.sphinx("rinoh", testroot="rinohtype-pdf")
+def test_rinohtype_pdf(
+    app, status, warning, check_build_success, get_sphinx_app_doctree
+):
+    app.build()
+    check_build_success(status, warning)
+    get_sphinx_app_doctree(app, regress=True)
+    # Doesn't currently regression pdf test output

--- a/tests/test_build/test_rinohtype_pdf.xml
+++ b/tests/test_build/test_rinohtype_pdf.xml
@@ -1,0 +1,6 @@
+<document source="index.rst">
+    <section ids="testing-pdf" names="testing\ pdf">
+        <title>
+            TESTING PDF
+        <compound classes="toctree-wrapper">
+            <toctree caption="Contents:" entries="(None,\ 'tabs')" glob="False" hidden="False" includefiles="tabs" includehidden="False" maxdepth="2" numbered="0" parent="index" rawcaption="Contents:" rawentries="" titlesonly="False">


### PR DESCRIPTION
Now uses base docutils classes when builder is unsupported, rather than custom sphinx-tabs nodes.

Added test for successful building with `rinohtype`. This includes regression testing of the XML, but not the output pdf. Turns out pdf's are quite awkward to diff!

Fixes #99 