### PR TITLE
📚 DOCS: Add PDF format to the Read The Docs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,3 +9,7 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  
+formats:
+  - pdf
+  

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
-  
+
 formats:
   - pdf
-  


### PR DESCRIPTION
That way users can preview what tabbed PDF output looks like in the official docs. This should help with questions about the current state PDF support, like in https://github.com/executablebooks/sphinx-tabs/issues/57.

I haven't set up a RTD project yet, so I just went off the [configuration docs](https://docs.readthedocs.io/en/stable/config-file/v2.html#formats), hopefully I got it right.