### PR TITLE
👌 IMPROVE: Add sphinx option to disable css from loading

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,12 @@ Custom lexers that have been loaded in the sphinx `conf.py` can be used with `co
    def setup(app):
       app.add_lexer('alias', MyCustomLexer())
 
+By default, the extension loads predefined CSS styles for tabs. To disable the CSS from loading, add the following to your `conf.py`:
+
+.. code-block:: python
+
+   sphinx_tabs_disable_css_loading = True
+
 
 Basic Tabs
 ===========

--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -299,11 +299,12 @@ def update_config(app, config):
                 app.add_css_file(path.as_posix())
             else:
                 app.add_stylesheet(path.as_posix())
-        if  path.suffix == ".js":
+        if path.suffix == ".js":
             if "add_script_file" in dir(app):
                 app.add_script_file(path.as_posix())
             else:
                 app.add_js_file(path.as_posix())
+
 
 # pylint: disable=unused-argument
 def update_context(app, pagename, templatename, context, doctree):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,12 @@ def check_asset_links(get_sphinx_app_output):
     """
 
     def check(
-        app, buildername="html", filename="index.html", encoding="utf-8", present=True
+        app,
+        buildername="html",
+        filename="index.html",
+        encoding="utf-8",
+        cssPresent=True,
+        jsPresent=True,
     ):
         content = get_sphinx_app_output(app, buildername, filename, encoding)
 
@@ -146,13 +151,16 @@ def check_asset_links(get_sphinx_app_output):
 
         all_refs = css_refs + js_refs
 
-        if present:
+        if cssPresent:
             css_present = all(any(a in ref for ref in all_refs) for a in css_assets)
-            js_present = all(any(a in ref for ref in js_refs) for a in js_assets)
             assert css_present
+        else:
+            assert not "sphinx_tabs" in css_refs
+        if jsPresent:
+            js_present = all(any(a in ref for ref in js_refs) for a in js_assets)
             assert js_present
         else:
-            assert not "sphinx_tabs" in css_refs + js_refs
+            assert not "sphinx_tabs" in js_refs
 
     return check
 

--- a/tests/roots/test-disable-css-loading/conf.py
+++ b/tests/roots/test-disable-css-loading/conf.py
@@ -1,0 +1,7 @@
+project = "sphinx-tabs test"
+master_doc = "index"
+source_suffix = ".rst"
+extensions = ["sphinx_tabs.tabs"]
+pygments_style = "sphinx"
+
+sphinx_tabs_disable_css_loading = True

--- a/tests/roots/test-disable-css-loading/index.rst
+++ b/tests/roots/test-disable-css-loading/index.rst
@@ -1,0 +1,17 @@
+.. tabs::
+
+   .. tab:: Apples
+
+      Apples are green, or sometimes red.
+
+   .. tab:: Pears
+
+      Pears are green.
+
+   .. tab:: Oranges
+
+      Oranges are orange.
+
+   .. tab:: 404
+
+      A number in the name.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,7 +10,7 @@ def test_basic():
 
 @pytest.mark.sphinx(testroot="notabs")
 def test_no_tabs(app, check_asset_links):
-    check_asset_links(app, present=False)
+    check_asset_links(app, cssPresent=False, jsPresent=False)
 
 
 @pytest.mark.parametrize("docname", ["index", "no_tabs1", "no_tabs2"])
@@ -19,7 +19,9 @@ def test_conditional_assets(app, docname, check_asset_links):
     if docname == "index":
         check_asset_links(app)
     else:
-        check_asset_links(app, filename=docname + ".html", present=False)
+        check_asset_links(
+            app, filename=docname + ".html", cssPresent=False, jsPresent=False
+        )
 
 
 @pytest.mark.sphinx(testroot="linenos")
@@ -62,3 +64,8 @@ def test_rinohtype_pdf(
 @pytest.mark.sphinx(testroot="disable-closing")
 def test_disable_closing(app, check_asset_links):
     check_asset_links(app)
+
+
+@pytest.mark.sphinx(testroot="disable-css-loading")
+def test_disable_css_loading(app, check_asset_links):
+    check_asset_links(app, cssPresent=False)

--- a/tests/test_build/test_disable_css_loading.html
+++ b/tests/test_build/test_disable_css_loading.html
@@ -1,0 +1,42 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="sphinx-tabs docutils container">
+    <div aria-label="Tabbed content" class="closeable" role="tablist">
+     <button aria-controls="panel-0-0-0" aria-selected="true" class="sphinx-tabs-tab" id="tab-0-0-0" name="0-0" role="tab" tabindex="0">
+      Apples
+     </button>
+     <button aria-controls="panel-0-0-1" aria-selected="false" class="sphinx-tabs-tab" id="tab-0-0-1" name="0-1" role="tab" tabindex="-1">
+      Pears
+     </button>
+     <button aria-controls="panel-0-0-2" aria-selected="false" class="sphinx-tabs-tab" id="tab-0-0-2" name="0-2" role="tab" tabindex="-1">
+      Oranges
+     </button>
+     <button aria-controls="panel-0-0-3" aria-selected="false" class="sphinx-tabs-tab" id="tab-0-0-3" name="0-3" role="tab" tabindex="-1">
+      404
+     </button>
+    </div>
+    <div aria-labelledby="tab-0-0-0" class="sphinx-tabs-panel" id="panel-0-0-0" name="0-0" role="tabpanel" tabindex="0">
+     <p>
+      Apples are green, or sometimes red.
+     </p>
+    </div>
+    <div aria-labelledby="tab-0-0-1" class="sphinx-tabs-panel" hidden="true" id="panel-0-0-1" name="0-1" role="tabpanel" tabindex="0">
+     <p>
+      Pears are green.
+     </p>
+    </div>
+    <div aria-labelledby="tab-0-0-2" class="sphinx-tabs-panel" hidden="true" id="panel-0-0-2" name="0-2" role="tabpanel" tabindex="0">
+     <p>
+      Oranges are orange.
+     </p>
+    </div>
+    <div aria-labelledby="tab-0-0-3" class="sphinx-tabs-panel" hidden="true" id="panel-0-0-3" name="0-3" role="tabpanel" tabindex="0">
+     <p>
+      A number in the name.
+     </p>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_build/test_disable_css_loading.xml
+++ b/tests/test_build/test_disable_css_loading.xml
@@ -1,0 +1,23 @@
+<document source="index.rst">
+    <container classes="sphinx-tabs" type="tab-element">
+        <div aria-label="Tabbed content" classes="closeable" role="tablist">
+            <button aria-controls="panel-0-0-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-0-0-0" name="0-0" role="tab" tabindex="0">
+                Apples
+            <button aria-controls="panel-0-0-1" aria-selected="false" classes="sphinx-tabs-tab" ids="tab-0-0-1" name="0-1" role="tab" tabindex="-1">
+                Pears
+            <button aria-controls="panel-0-0-2" aria-selected="false" classes="sphinx-tabs-tab" ids="tab-0-0-2" name="0-2" role="tab" tabindex="-1">
+                Oranges
+            <button aria-controls="panel-0-0-3" aria-selected="false" classes="sphinx-tabs-tab" ids="tab-0-0-3" name="0-3" role="tab" tabindex="-1">
+                404
+        <div aria-labelledby="tab-0-0-0" classes="sphinx-tabs-panel" ids="panel-0-0-0" name="0-0" role="tabpanel" tabindex="0">
+            <paragraph>
+                Apples are green, or sometimes red.
+        <div aria-labelledby="tab-0-0-1" classes="sphinx-tabs-panel" hidden="true" ids="panel-0-0-1" name="0-1" role="tabpanel" tabindex="0">
+            <paragraph>
+                Pears are green.
+        <div aria-labelledby="tab-0-0-2" classes="sphinx-tabs-panel" hidden="true" ids="panel-0-0-2" name="0-2" role="tabpanel" tabindex="0">
+            <paragraph>
+                Oranges are orange.
+        <div aria-labelledby="tab-0-0-3" classes="sphinx-tabs-panel" hidden="true" ids="panel-0-0-3" name="0-3" role="tabpanel" tabindex="0">
+            <paragraph>
+                A number in the name.


### PR DESCRIPTION
Closes https://github.com/executablebooks/sphinx-tabs/issues/115

# How to test this PR

To disable the CSS from loading, add the following to your ``conf.py``:

```python
sphinx_tabs_disable_css_loading = True
 ```

Once you build the docs, you should see all tabs unstyled:

![image](https://user-images.githubusercontent.com/9107969/119315535-d8d18900-bc6d-11eb-807a-de97f21868f8.png)

 
 