### PR TITLE
🧪 TESTS: Fix Jest version for JS testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
       with:
         node-version: '15'
     - name: Install jest
-      run: npm install jest
+      run: npm install jest@26.6.3
     - name: Run JS tests
       run: npm test
 


### PR DESCRIPTION
Latest Jest version (27.x) includes a breaking change. Fixing to 26.6.3