### PR TITLE
[ENH] Use Sphinx HTML assets policy to decide whether include assets

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -1,6 +1,7 @@
 """ Tabbed views for Sphinx, with HTML builder """
 
 import base64
+import sphinx
 from pathlib import Path
 from functools import partial
 
@@ -313,7 +314,12 @@ def update_context(app, pagename, templatename, context, doctree):
         return
     visitor = _FindTabsDirectiveVisitor(doctree)
     doctree.walk(visitor)
-    if not visitor.found_tabs_directive:
+
+    include_assets_in_all_pages = False
+    if sphinx.version_info >= (4, 1, 0):
+        include_assets_in_all_pages = app.registry.html_assets_policy == 'always'
+
+    if not visitor.found_tabs_directive and not include_assets_in_all_pages:
         paths = [Path("_static") / f for f in FILES]
         if "css_files" in context:
             context["css_files"] = context["css_files"][:]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,6 +25,15 @@ def test_conditional_assets(app, docname, check_asset_links):
         )
 
 
+@pytest.mark.parametrize("docname", ["index", "no_tabs1", "no_tabs2"])
+@pytest.mark.sphinx(testroot="conditionalassets")
+@pytest.mark.skipif(
+    sphinx.version_info[:2] >= (4, 1), reason="Test uses Sphinx 4.1 config"
+)
+def test_conditional_assets(app, docname, check_asset_links):
+    check_asset_links(app, filename=docname + ".html")
+
+
 @pytest.mark.sphinx(testroot="linenos")
 @pytest.mark.skipif(
     sphinx.version_info[:2] >= (4, 0), reason="Test uses Sphinx 3 code blocks"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -25,12 +25,32 @@ def test_conditional_assets(app, docname, check_asset_links):
         )
 
 
+@pytest.mark.noautobuild
 @pytest.mark.parametrize("docname", ["index", "no_tabs1", "no_tabs2"])
 @pytest.mark.sphinx(testroot="conditionalassets")
 @pytest.mark.skipif(
-    sphinx.version_info[:2] >= (4, 1), reason="Test uses Sphinx 4.1 config"
+    sphinx.version_info[:2] < (4, 1), reason="Test uses Sphinx 4.1 config"
 )
-def test_conditional_assets(app, docname, check_asset_links):
+def test_conditional_assets_html_assets_policy(
+    app,
+    docname,
+    status,
+    warning,
+    check_build_success,
+    get_sphinx_app_doctree,
+    regress_sphinx_app_output,
+    check_asset_links,
+):
+    app.set_html_assets_policy("always")
+
+    # Following lines are copied from ``auto_build_and_check`` since we need to
+    # set a config in the build object before auto build. Because of this, we
+    # need to use ``noautobuild``.
+    app.build()
+    check_build_success(status, warning)
+    get_sphinx_app_doctree(app, regress=True)
+    regress_sphinx_app_output(app)
+
     check_asset_links(app, filename=docname + ".html")
 
 


### PR DESCRIPTION
Sphinx v4.1.0 will include `Sphinx.registry.html_assets_policy` that defines the
policy to whether include or not HTML assets in pages where the extension is not
used.

This PR makes usage of this policy to decide if sphinx-tabs assets should be
included or not in the page that's being rendered.

Reference: https://github.com/sphinx-doc/sphinx/issues/9115