### PR TITLE
Fix test_other_with_assets_new_style w/Sphinx 4.0

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -64,9 +64,9 @@ def test_other_with_assets(app, check_asset_links):
 
 @pytest.mark.sphinx(testroot="linenos")
 @pytest.mark.skipif(
-    sphinx.version_info[:2] <= (4, 0), reason="Test uses Sphinx 4 code blocks"
+    sphinx.version_info[:2] < (4, 0), reason="Test uses Sphinx 4 code blocks"
 )
-def test_other_With_assets_new_style(app, check_asset_links):
+def test_other_with_assets_new_style(app, check_asset_links):
     check_asset_links(app)
 
 


### PR DESCRIPTION
Make the test work with Sphinx 4.0.x. (It was skipped when testing with 4.0.2)
Fix the typo so that the regression file is actually found - it threw FileNotFoundError once the condition was corrected.