### PR TITLE
👌 IMPROVE: Change CSS to remove extra white-space in panel

### DIFF
--- a/sphinx_tabs/static/tabs.css
+++ b/sphinx_tabs/static/tabs.css
@@ -48,6 +48,10 @@
   padding: 0.4rem;
 }
 
+.sphinx-tabs-panel p {
+  margin-bottom: 0;
+}
+
 .sphinx-tab img {
 	margin-bottom: 24 px;
 }


### PR DESCRIPTION
Some themes pad paragraph elements with a `bottom-margin`. This change removes that margin when `p` element is within a panel.

Fixes #139 