### PR TITLE
[fix] don't append CSS files to the end of html_static_path list

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -355,7 +355,7 @@ def setup(app):
     static_dir = Path(__file__).parent / "static"
     app.connect(
         "builder-inited",
-        (lambda app: app.config.html_static_path.append(static_dir.as_posix())),
+        (lambda app: app.config.html_static_path.insert(0, static_dir.as_posix())),
     )
     app.connect("config-inited", update_config)
     app.connect("html-page-context", update_context)


### PR DESCRIPTION
html_static_path is a list of paths that contain custom static files.  They are
copied to the output’s _static directory **after** the theme’s static files, so a
file named default.css will overwrite the theme’s default.css [1]

Without this patch a tabs.css can't be overwritten by the `conf.py` file:

    html_static_path = [ 'static/tabs.css', ]

The /static folder from sphinx-tabs needs to be added in front of
html_static_path since the last item in the list will be written last to
/_static.

[1] https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_static_path

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>