### PR TITLE
[fix] prefers-color-scheme: use dark theme if body[data-theme="auto"]

### DIFF
--- a/sphinx_tabs/static/tabs.css
+++ b/sphinx_tabs/static/tabs.css
@@ -55,23 +55,18 @@
 /* Dark theme preference styling */
 
 @media (prefers-color-scheme: dark) {
-  body:not([data-theme="light"]) .sphinx-tabs-panel {
+  body[data-theme="auto"] .sphinx-tabs-panel {
     color: white;
     background-color: rgb(50, 50, 50);
   }
 
-  body:not([data-theme="light"]) .sphinx-tabs-tab {
+  body[data-theme="auto"] .sphinx-tabs-tab {
     color: white;
-    font-size: 16px;
-    font-weight: 400;
     background-color: rgba(255, 255, 255, 0.05);
   }
 
-  body:not([data-theme="light"]) .sphinx-tabs-tab[aria-selected="true"] {
-    font-weight: 700;
-    border: 1px solid #a0b3bf;
+  body[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"] {
     border-bottom: 1px solid rgb(50, 50, 50);
-    margin: -1px;
     background-color: rgb(50, 50, 50);
   }
 }
@@ -85,16 +80,10 @@ body[data-theme="dark"] .sphinx-tabs-panel {
 
 body[data-theme="dark"] .sphinx-tabs-tab {
   color: white;
-  font-size: 16px;
-  font-weight: 400;
-  border: 1px solid rgba(255, 255, 255, 0.15);
   background-color: rgba(255, 255, 255, 0.05);
 }
 
 body[data-theme="dark"] .sphinx-tabs-tab[aria-selected="true"] {
-  font-weight: 700;
-  border: 1px solid #a0b3bf;
   border-bottom: 2px solid rgb(50, 50, 50);
-  margin: -1px;
   background-color: rgb(50, 50, 50);
 }


### PR DESCRIPTION
Before this patch the CSS implementation assumes that "dark" is supported by the
theme if the `data-theme` attribute of the `<body>` tag is unset.

Since most themes are using "light" colors (compare https://sphinx-themes.org)
and do not set `data-theme` it is better to assume light is the default, even
when the browser setting `prefers-color-scheme: dark`!

BTW: remove duplication of styles from dark/light theme that are already set in
the common style.

----

To test enable _dark_ mode in your browser (prefers-color-scheme: dark).

Current master (default theme):

![image](https://user-images.githubusercontent.com/554536/158019156-aec33668-a0e7-40f0-aecb-80c0fddfc822.png)

After this patch applied (default theme):

![image](https://user-images.githubusercontent.com/554536/158019232-df483623-8bc6-4585-8e76-552795e4b2e0.png)

I also tested `furo` theme which supports a _dark/light_ mode. This is the result when browser (prefers-color-scheme: dark):

![image](https://user-images.githubusercontent.com/554536/158019307-416d5104-f939-43f5-973e-0cf6e865c0ea.png)

BTW: the result is the same if you toggle from "auto" to "dark".

And here is the result when you toggle into "light" mode ..

![image](https://user-images.githubusercontent.com/554536/158019372-1f3c58b5-1b32-4229-aa0d-3a9dfd18732f.png)

----

Closes: #152