### PR TITLE
🐛 FIX: Fix to stop stripping of first line in MyST content

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -184,7 +184,7 @@ class TabDirective(SphinxDirective):
         else:
             panel["hidden"] = "true"
 
-        self.state.nested_parse(self.content[2:], self.content_offset, panel)
+        self.state.nested_parse(self.content[1:], self.content_offset, panel)
 
         if self.env.app.builder.name not in get_compatible_builders(self.env.app):
             # Use base docutils classes
@@ -194,7 +194,7 @@ class TabDirective(SphinxDirective):
             panel = nodes.container()
 
             self.state.nested_parse(self.content[0:1], 0, tab_name)
-            self.state.nested_parse(self.content[2:], self.content_offset, panel)
+            self.state.nested_parse(self.content[1:], self.content_offset, panel)
 
             tab += tab_name
             outer_node += tab


### PR DESCRIPTION
This pull request fixes a problem where the first line of content in a `tab` or `group-tab` directive is stripped in MyST.

The following in MyST will render with the first line in the `tab` and `group-tab` blocks stripped.

`````
````{tabs}
```{tab} test
The first line.
The second line.
```
````

````{tabs}
```{group-tab} test
The first line.
The second line.
```
````

````{tabs}
```{code-tab} py
# The first line.
# The second line.
```
````
`````

![image](https://user-images.githubusercontent.com/12150295/174069008-5a296a65-70b2-40ce-8092-9d2a5902ccd9.png)

The cause of this is the index specification when getting the directive content within the `TabDirective.run` method.

https://github.com/executablebooks/sphinx-tabs/blob/0b04c8eb37075d57f6d5ad321ca40f4e800894f8/sphinx_tabs/tabs.py#L187

The directive syntax in reStructuredText requires a blank line before the content, so `self.content[1]` is guaranteed to be a blank line. However, MyST has no such restriction; the actual content starts from `self.content[1]` when written as in the example above. Therefore, if one slices it as `self.content[2:]`, the first line of the content will be stripped.

So, I modified it so that the first line of content is parsed in MyST by slicing the content from `[1:]`. I think that this change does not affect the parsing of content in reStructuredText.