### PR TITLE
Remove no longer needed declare_namespace()

### DIFF
--- a/sphinx_tabs/__init__.py
+++ b/sphinx_tabs/__init__.py
@@ -1,3 +1,1 @@
 __version__ = "3.4.1"
-
-__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
This fix removes declare_namespace() which is no longer needed. it used old style namespaces which has been using `pkg_resources` module which is part of the `setuptools` and which is as well depreceted now.