### PR TITLE
Make the tests pass with Sphinx 7.1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from pathlib import Path
 from bs4 import BeautifulSoup
+import sphinx
 from sphinx.testing.path import path
 
 from sphinx_tabs.tabs import FILES
@@ -123,6 +124,11 @@ def get_sphinx_app_doctree(file_regression):
             text = doctree.pformat()  # type: str
             for find, rep in (replace or {}).items():
                 text = text.replace(find, rep)
+            if sphinx.version_info < (7, 1):
+                text = text.replace(
+                    '<document source="index.rst">',
+                    "<document source=\"index.rst\" translation_progress=\"{'total': 0, 'translated': 0}\">",
+                )
             file_regression.check(text, extension=extension)
 
         return doctree

--- a/tests/test_build/test_basic.xml
+++ b/tests/test_build/test_basic.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <container classes="sphinx-tabs" type="tab-element">
         <div aria-label="Tabbed content" classes="closeable" role="tablist">
             <button aria-controls="panel-0-0-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-0-0-0" name="0-0" role="tab" tabindex="0">

--- a/tests/test_build/test_conditional_assets_html_assets_policy_index_.xml
+++ b/tests/test_build/test_conditional_assets_html_assets_policy_index_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_conditional_assets_html_assets_policy_no_tabs1_.xml
+++ b/tests/test_build/test_conditional_assets_html_assets_policy_no_tabs1_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_conditional_assets_html_assets_policy_no_tabs2_.xml
+++ b/tests/test_build/test_conditional_assets_html_assets_policy_no_tabs2_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_conditional_assets_index_.xml
+++ b/tests/test_build/test_conditional_assets_index_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_conditional_assets_no_tabs1_.xml
+++ b/tests/test_build/test_conditional_assets_no_tabs1_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_conditional_assets_no_tabs2_.xml
+++ b/tests/test_build/test_conditional_assets_no_tabs2_.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <compound classes="toctree-wrapper">
         <toctree caption="True" entries="(None,\ 'no_tabs1') (None,\ 'no_tabs2')" glob="False" hidden="False" includefiles="no_tabs1 no_tabs2" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">
     <section ids="fruits" names="fruits">

--- a/tests/test_build/test_custom_lexer.xml
+++ b/tests/test_build/test_custom_lexer.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <container classes="sphinx-tabs" type="tab-element">
         <div aria-label="Tabbed content" classes="closeable" role="tablist">
             <button aria-controls="panel-0-QllP" aria-selected="true" classes="sphinx-tabs-tab code-tab group-tab" ids="tab-0-QllP" name="QllP" role="tab" tabindex="0">

--- a/tests/test_build/test_disable_closing.xml
+++ b/tests/test_build/test_disable_closing.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <container classes="sphinx-tabs" type="tab-element">
         <div aria-label="Tabbed content" role="tablist">
             <button aria-controls="panel-0-0-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-0-0-0" name="0-0" role="tab" tabindex="0">

--- a/tests/test_build/test_disable_css_loading.xml
+++ b/tests/test_build/test_disable_css_loading.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <container classes="sphinx-tabs" type="tab-element">
         <div aria-label="Tabbed content" classes="closeable" role="tablist">
             <button aria-controls="panel-0-0-0" aria-selected="true" classes="sphinx-tabs-tab" ids="tab-0-0-0" name="0-0" role="tab" tabindex="0">

--- a/tests/test_build/test_nested_markup.xml
+++ b/tests/test_build/test_nested_markup.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <section ids="markup-in-tab-titles" names="markup\ in\ tab\ titles">
         <title>
             Markup in Tab Titles

--- a/tests/test_build/test_no_tabs.xml
+++ b/tests/test_build/test_no_tabs.xml
@@ -1,3 +1,3 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <paragraph>
         There are no tabs here

--- a/tests/test_build/test_other_with_assets.xml
+++ b/tests/test_build/test_other_with_assets.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <container classes="sphinx-tabs" type="tab-element">
         <div aria-label="Tabbed content" classes="closeable" role="tablist">
             <button aria-controls="panel-0-Qysr" aria-selected="true" classes="sphinx-tabs-tab code-tab group-tab" ids="tab-0-Qysr" name="Qysr" role="tab" tabindex="0">

--- a/tests/test_build/test_rinohtype_pdf.xml
+++ b/tests/test_build/test_rinohtype_pdf.xml
@@ -1,4 +1,4 @@
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
     <section ids="testing-pdf" names="testing\ pdf">
         <title>
             TESTING PDF


### PR DESCRIPTION
The tests were failing with this diff:
```diff
-<document source="index.rst">
+<document source="index.rst" translation_progress="{'total': 0, 'translated': 0}">
```

See https://bugs.debian.org/1042589 for the full log.

This was caused by sphinx-doc/sphinx#11509, which is part of Sphinx ≥ 7.1.0.