### PR TITLE
Fix slice assignment in update_context()

### DIFF
--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -325,12 +325,12 @@ def update_context(app, pagename, templatename, context, doctree):
     if not visitor.found_tabs_directive and not include_assets_in_all_pages:
         paths = [Path("_static") / f for f in FILES]
         if "css_files" in context:
-            context["css_files"] = context["css_files"][:]
+            context["css_files"][:] = context["css_files"]
             for path in paths:
                 if path.suffix == ".css" and path in context["css_files"]:
                     context["css_files"].remove(path.as_posix())
         if "script_files" in context:
-            context["script_files"] = context["script_files"][:]
+            context["script_files"][:] = context["script_files"]
             for path in paths:
                 if path.suffix == ".js" and path.as_posix() in context["script_files"]:
                     context["script_files"].remove(path.as_posix())


### PR DESCRIPTION
I have to be honest, I'm not familiar with slice assignment like these, however inspired by https://github.com/sphinx-doc/sphinx/blob/v7.1.2/sphinx/builders/html/__init__.py#L1071-L1073 I think we may have flipped it here. Based on my testing it no longer strips script_files from other extensions while still properly removing tabs.js when it's not used.