### PR TITLE
FIX: unpin docutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/executablebooks/sphinx-tabs",
     license="MIT",
     python_requires="~=3.7",
-    install_requires=["sphinx", "pygments", "docutils~=0.18.0"],
+    install_requires=["sphinx", "pygments", "docutils>=0.18.0"],
     extras_require={
         "testing": [
             "coverage",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/executablebooks/sphinx-tabs",
     license="MIT",
     python_requires="~=3.7",
-    install_requires=["sphinx", "pygments", "docutils>=0.18.0"],
+    install_requires=["sphinx", "pygments", "docutils"],
     extras_require={
         "testing": [
             "coverage",


### PR DESCRIPTION
Unless we _know_ that docutils is broken for some version, and will be in future, we should unpin here so that downstream users are not blocked.

AFAICT, there's no strong reason in _this_ package to pin?

@foster999 are you OK with this change?