### PR TITLE
Drop usage of internal API when conditionally including assets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         pytest --cov=sphinx_tabs --cov-report=xml --cov-report=term-missing
     - name: Upload to Codecov
       if: matrix.python-version == '3.10' && github.repository == 'executablebooks/sphinx-tabs'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         name: sphinx-tabs-pytests-py3.10
         flags: pytests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
     - id: check-json
     - id: check-yaml
@@ -11,17 +11,17 @@ repos:
         ".xml"
 
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.48"
+    rev: "0.49"
     hooks:
     - id: check-manifest
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.8.0
     hooks:
     - id: black
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.14.3
+    rev: v3.2.6
     hooks:
     - id: pylint
       args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
     - id: pylint
       args:
-        - --disable=missing-docstring,similarities,fixme,bad-continuation
+        - --disable=missing-docstring,similarities,fixme
       additional_dependencies:
         - sphinx
         - docutils

--- a/pylint.cfg
+++ b/pylint.cfg
@@ -2,7 +2,7 @@
 extension-pkg-whitelist=lxml
 
 [MESSAGES CONTROL]
-disable=missing-docstring,similarities,fixme,bad-continuation
+disable=missing-docstring,similarities,fixme
 
 [REPORTS]
 reports=no

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/executablebooks/sphinx-tabs",
     license="MIT",
     python_requires=">=3.7",
-    install_requires=["sphinx", "pygments", "docutils"],
+    install_requires=["sphinx>=1.8", "pygments", "docutils"],
     extras_require={
         "testing": [
             "coverage",

--- a/sphinx_tabs/tabs.py
+++ b/sphinx_tabs/tabs.py
@@ -312,18 +312,9 @@ def update_context(app, pagename, templatename, context, doctree):
     if visitor.found_tabs_directive or include_assets_in_all_pages:
         if not app.config.sphinx_tabs_disable_css_loading:
             for css in CSS_FILES:
-                if "add_css_file" in dir(app):
-                    app.add_css_file(css)
-                else:
-                    # support old Sphinx versions
-                    app.add_stylesheet(css)
-
+                app.add_css_file(css)
         for js in JS_FILES:
-            if "add_js_file" in dir(app):
-                app.add_js_file(js)
-            else:
-                # support old Sphinx versions
-                app.add_script_file(js)
+            app.add_js_file(js)
 
 
 # pylint: enable=unused-argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from bs4 import BeautifulSoup
 import sphinx
 
-from sphinx_tabs.tabs import FILES
+from sphinx_tabs.tabs import JS_FILES, CSS_FILES
 
 pytest_plugins = "sphinx.testing.fixtures"
 
@@ -152,9 +152,6 @@ def check_asset_links(get_sphinx_app_output):
     ):
         content = get_sphinx_app_output(app, buildername, filename, encoding)
 
-        css_assets = [f for f in FILES if f.endswith(".css")]
-        js_assets = [f for f in FILES if f.endswith(".js")]
-
         soup = BeautifulSoup(content, "html.parser")
         stylesheets = soup.find_all("link", {"rel": "stylesheet"}, href=True)
         css_refs = [s["href"] for s in stylesheets]
@@ -165,12 +162,12 @@ def check_asset_links(get_sphinx_app_output):
         all_refs = css_refs + js_refs
 
         if cssPresent:
-            css_present = all(any(a in ref for ref in all_refs) for a in css_assets)
+            css_present = all(any(a in ref for ref in all_refs) for a in CSS_FILES)
             assert css_present
         else:
             assert not "sphinx_tabs" in css_refs
         if jsPresent:
-            js_present = all(any(a in ref for ref in js_refs) for a in js_assets)
+            js_present = all(any(a in ref for ref in js_refs) for a in JS_FILES)
             assert js_present
         else:
             assert not "sphinx_tabs" in js_refs


### PR DESCRIPTION
Fixes #197 by reversing the logic of how JS/CSS assets are added to pages.

Rather than adding assets to the app and using undocumented API to *remove* them when not needed, do the exact opposite and only *add* them to the local html-page-context when building a page that uses the directive.