### PR TITLE
[FIX] Detect dark mode in a wider range of sphinx themes

### DIFF
--- a/sphinx_tabs/static/tabs.css
+++ b/sphinx_tabs/static/tabs.css
@@ -55,17 +55,20 @@
 /* Dark theme preference styling */
 
 @media (prefers-color-scheme: dark) {
-  body[data-theme="auto"] .sphinx-tabs-panel {
+  body[data-theme="auto"] .sphinx-tabs-panel,
+  html[data-theme="auto"] .sphinx-tabs-panel {
     color: white;
     background-color: rgb(50, 50, 50);
   }
 
-  body[data-theme="auto"] .sphinx-tabs-tab {
+  body[data-theme="auto"] .sphinx-tabs-tab,
+  html[data-theme="auto"] .sphinx-tabs-tab {
     color: white;
     background-color: rgba(255, 255, 255, 0.05);
   }
 
-  body[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"] {
+  body[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"],
+  html[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"] {
     border-bottom: 1px solid rgb(50, 50, 50);
     background-color: rgb(50, 50, 50);
   }
@@ -73,17 +76,26 @@
 
 /* Explicit dark theme styling */
 
-body[data-theme="dark"] .sphinx-tabs-panel {
+body[data-theme="dark"] .sphinx-tabs-panel,
+html[data-theme="auto"] .sphinx-tabs-panel,
+body.theme-dark .sphinx-tabs-panel,
+html.dark .sphinx-tabs-panel {
   color: white;
   background-color: rgb(50, 50, 50);
 }
 
-body[data-theme="dark"] .sphinx-tabs-tab {
+body[data-theme="dark"] .sphinx-tabs-tab,
+html[data-theme="auto"] .sphinx-tabs-tab,
+body.theme-dark .sphinx-tabs-tab,
+html.dark .sphinx-tabs-tab {
   color: white;
   background-color: rgba(255, 255, 255, 0.05);
 }
 
-body[data-theme="dark"] .sphinx-tabs-tab[aria-selected="true"] {
+body[data-theme="dark"] .sphinx-tabs-tab[aria-selected="true"],
+html[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"],
+body.theme-dark .sphinx-tabs-tab[aria-selected="true"],
+html.dark .sphinx-tabs-tab[aria-selected="true"] {
   border-bottom: 2px solid rgb(50, 50, 50);
   background-color: rgb(50, 50, 50);
 }

--- a/sphinx_tabs/static/tabs.css
+++ b/sphinx_tabs/static/tabs.css
@@ -56,19 +56,19 @@
 
 @media (prefers-color-scheme: dark) {
   body[data-theme="auto"] .sphinx-tabs-panel,
-  html[data-theme="auto"] .sphinx-tabs-panel {
+  html[data-mode="auto"] .sphinx-tabs-panel {
     color: white;
     background-color: rgb(50, 50, 50);
   }
 
   body[data-theme="auto"] .sphinx-tabs-tab,
-  html[data-theme="auto"] .sphinx-tabs-tab {
+  html[data-mode="auto"] .sphinx-tabs-tab {
     color: white;
     background-color: rgba(255, 255, 255, 0.05);
   }
 
   body[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"],
-  html[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"] {
+  html[data-mode="auto"] .sphinx-tabs-tab[aria-selected="true"] {
     border-bottom: 1px solid rgb(50, 50, 50);
     background-color: rgb(50, 50, 50);
   }
@@ -77,7 +77,7 @@
 /* Explicit dark theme styling */
 
 body[data-theme="dark"] .sphinx-tabs-panel,
-html[data-theme="auto"] .sphinx-tabs-panel,
+html[data-mode="auto"] .sphinx-tabs-panel,
 body.theme-dark .sphinx-tabs-panel,
 html.dark .sphinx-tabs-panel {
   color: white;
@@ -85,7 +85,7 @@ html.dark .sphinx-tabs-panel {
 }
 
 body[data-theme="dark"] .sphinx-tabs-tab,
-html[data-theme="auto"] .sphinx-tabs-tab,
+html[data-mode="auto"] .sphinx-tabs-tab,
 body.theme-dark .sphinx-tabs-tab,
 html.dark .sphinx-tabs-tab {
   color: white;
@@ -93,7 +93,7 @@ html.dark .sphinx-tabs-tab {
 }
 
 body[data-theme="dark"] .sphinx-tabs-tab[aria-selected="true"],
-html[data-theme="auto"] .sphinx-tabs-tab[aria-selected="true"],
+html[data-mode="auto"] .sphinx-tabs-tab[aria-selected="true"],
 body.theme-dark .sphinx-tabs-tab[aria-selected="true"],
 html.dark .sphinx-tabs-tab[aria-selected="true"] {
   border-bottom: 2px solid rgb(50, 50, 50);


### PR DESCRIPTION
The CSS file currently uses `body[data-theme="dark"]` to detect whether the theme is using dark mode. But different Sphinx themes use different mechanisms for marking this.

Here is a summary of the mechanisms used by all the themes in https://sphinx-themes.org/ which are currently building and which support dark mode.

- **Furo**: `body[data-theme="dark"]` and `body[data-theme="auto"]`
- **Book**: `html[data-mode="dark"]` and `html[data-mode="auto"]`
- **PyData**: `html[data-mode="dark"]` and `html[data-mode="auto"]`
- **Press**: `body.theme-dark`. The auto mode either sets this or `body.theme-light`
- **Piccolo**: `html[data-mode="dark"]` and `html[data-mode="auto"]`
- **Awesome**: `html.dark`. The auto mode either sets this class or removes it
- **Nefertiti**: `html.dark`. The auto mode either sets this class or removes it
- **PDJ**: Updating the `media` attribute of stylesheet `link` elements to toggle these stylesheets on and off. Supporting this would require some JavaScript hacking.
- **Python Documentation**: Updating the `media` attribute of stylesheet `link` elements to toggle these stylesheets on and off. Supporting this would require some JavaScript hacking.
- **Wagtail**: `body.theme-dark`. There's no auto mode

Overall there are five different mechanisms. This PR enables detecting dark mode in the four cases where this can be done using pure CSS.

Fixes #193
Fixes #194 
Fixes #195 