### PR TITLE
Fix Resolve complex tabs not displaying properly, such as MySt Admonitions

### DIFF
--- a/sphinx_tabs/static/tabs.js
+++ b/sphinx_tabs/static/tabs.js
@@ -91,6 +91,9 @@ function selectTab(tab) {
   // Show the associated panel
   document
     .getElementById(tab.getAttribute("aria-controls"))
+    .parentNode.removeAttribute("hidden");
+  document
+    .getElementById(tab.getAttribute("aria-controls"))
     .removeAttribute("hidden");
 }
 


### PR DESCRIPTION
For example, the code below contains MySt Admonitions in the tabs. 
The parent div of the tab content's div does not remove the hidden attribute.
```
::::{tabs}

:::{tab} attention
:::{attention}
attention
:::
:::

:::{tab} caution
:::{caution}
caution
:::
:::

::::
```